### PR TITLE
Reorganização dos arquivos e linter

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,35 @@
+{
+    "extends": [
+      "airbnb",
+      "prettier",
+      "plugin:react/recommended"
+    ],
+    "plugins": ["jsx-a11y", "import", "prettier"],
+    "env": {
+      "node": true,
+      "es6": true
+    },
+    "parserOptions": {
+      "sourceType": "module",
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    },
+    "rules": {
+      "comma-dangle": 0,
+      "no-throw-literal": 0,
+      "new-cap": 0,
+      "max-len": 0,
+      "generator-star-spacing": 0,
+      "no-underscore-dangle": ["error", { "allow": ["_id", "_source", "_fields", "_values", "_enumConfig"] }],
+      "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
+      "import/no-dynamic-require": 0,
+      "class-methods-use-this": 0,
+      "react/jsx-no-bind": 0,
+      "react/prefer-stateless-function": 0,
+      "react/jsx-filename-extension": 0,
+      "react/forbid-prop-types": 0,
+      "prettier/prettier": ["error", { "singleQuote": true, "postcss": true }]
+    }
+  }
+  

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # api-camara-graphql
 Uma implementação da API do portal de dados abertos utilizando GraphQL
+
+
+# Sobre os dados
+
+## Endpoint implementados
+- [ ] Blocos
+- [ ] Votações
+- [ ] Partidos
+- [ ] Deputados
+- [ ] Legislaturas
+- [ ] Referências
+- [ ] Proposições
+- [ ] Eventos
+- [ ] Órgãos

--- a/index.js
+++ b/index.js
@@ -1,53 +1,9 @@
 const { GraphQLServer } = require('graphql-yoga')
-const axios = require('axios')
-
-const resolvers = {
-  Query: {
-    legislators: async (obj, args, context, info) => {
-      const { nome, ordenarPor, siglaPartido } = args
-      return axios
-        .get(
-          'https://dadosabertos.camara.leg.br/api/v2/deputados',
-          {
-            params: {
-              nome,
-              ordenarPor,
-              siglaPartido
-            }
-          }
-        )
-        .then(function(response) {
-          return response.data.dados
-        })
-        .catch(function(error) {
-          console.log(error)
-        })
-    }
-  },
-  Legislator: {
-    partido(args) {
-      const sigla = args.siglaPartido;
-      return axios
-      .get(
-        'https://dadosabertos.camara.leg.br/api/v2/partidos',
-        {
-          params: {
-            sigla
-          }
-        }
-      )
-      .then(function(response) {
-        return response.data.dados
-      })
-      .catch(function(error) {
-        console.log(error)
-      })
-    }
-  }
-}
+const typeDefs = require('./src/graphql/typeDefs')
+const resolvers = require('./src/graphql/resolvers')
 
 const server = new GraphQLServer({
-  typeDefs: './src/schema.graphql',
+  typeDefs,
   resolvers
 })
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "axios": "^0.18.0",
     "graphql": "^0.13.2",
-    "graphql-yoga": "^1.8.5"
+    "graphql-yoga": "^1.8.5",
+    "merge-graphql-schemas": "^1.5.1"
   },
   "devDependencies": {
     "eslint": "^4.19.1",

--- a/src/graphql/resolvers.js
+++ b/src/graphql/resolvers.js
@@ -1,0 +1,6 @@
+const path = require('path')
+const { fileLoader, mergeResolvers } = require('merge-graphql-schemas')
+
+const resolversArray = fileLoader(path.join(__dirname, './resolvers'))
+
+module.exports = mergeResolvers(resolversArray)

--- a/src/graphql/resolvers/legislatorResolver.js
+++ b/src/graphql/resolvers/legislatorResolver.js
@@ -1,0 +1,40 @@
+const axios = require('axios')
+
+module.exports = {
+  Query: {
+    legislators: async (obj, args, context, info) => {
+      const { nome, ordenarPor, siglaPartido } = args
+      return axios
+        .get('https://dadosabertos.camara.leg.br/api/v2/deputados', {
+          params: {
+            nome,
+            ordenarPor,
+            siglaPartido
+          }
+        })
+        .then(function(response) {
+          return response.data.dados
+        })
+        .catch(function(error) {
+          console.log(error)
+        })
+    }
+  },
+  Legislator: {
+    partido(args) {
+      const sigla = args.siglaPartido
+      return axios
+        .get('https://dadosabertos.camara.leg.br/api/v2/partidos', {
+          params: {
+            sigla
+          }
+        })
+        .then(function(response) {
+          return response.data.dados
+        })
+        .catch(function(error) {
+          console.log(error)
+        })
+    }
+  }
+}

--- a/src/graphql/typeDefs.js
+++ b/src/graphql/typeDefs.js
@@ -1,0 +1,6 @@
+const path = require('path')
+const { fileLoader, mergeTypes } = require('merge-graphql-schemas')
+
+const typesArray = fileLoader(path.join(__dirname, './types'))
+
+module.exports = mergeTypes(typesArray, { all: true })

--- a/src/graphql/types/legislatorType.graphql
+++ b/src/graphql/types/legislatorType.graphql
@@ -1,10 +1,3 @@
-type Partido {
-  id: Int!
-  sigla: String!
-  nome: String!
-  uri: String!
-}
-
 type Legislator {
   id: Int!
   nome: String!
@@ -14,7 +7,7 @@ type Legislator {
   siglaUf: String!
   idLegislatura: Int!
   urlFoto: String!
-  partido: [Partido]
+  partido: [Party]
 }
 
 type Query {

--- a/src/graphql/types/partyType.graphql
+++ b/src/graphql/types/partyType.graphql
@@ -1,0 +1,6 @@
+type Party {
+  id: Int!
+  sigla: String!
+  nome: String!
+  uri: String!
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -473,6 +473,10 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+deepmerge@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.1.0.tgz#511a54fff405fc346f0240bb270a3e9533a31102"
+
 define-properties@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
@@ -1142,9 +1146,19 @@ is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
 
+is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
+is-glob@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
+  dependencies:
+    is-extglob "^2.1.1"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -1299,6 +1313,14 @@ media-typer@0.3.0:
 merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+
+merge-graphql-schemas@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/merge-graphql-schemas/-/merge-graphql-schemas-1.5.1.tgz#a9682d4067c0c80c0db631ec56b4573731e93dc3"
+  dependencies:
+    deepmerge "^2.1.0"
+    glob "^7.1.2"
+    is-glob "^4.0.0"
 
 methods@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Adicionado o linter e prettier do projeto para controle de padrões de código.
Criada uma nova estrutura de organização de tipos e resolvers do graphql utilizando o merge-graphql-schemas.