### PR TITLE
Estrutura dos demais dados dos deputados e mudança no resolver

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch Program",
+            "program": "${workspaceFolder}/index.js"
+        }
+    ]
+}

--- a/src/graphql/resolvers/legislatorResolver.js
+++ b/src/graphql/resolvers/legislatorResolver.js
@@ -3,23 +3,34 @@ const axios = require('axios')
 module.exports = {
   Query: {
     legislators: async (obj, args, context, info) => {
-      return axios
+      const legislators = await axios
         .get('https://dadosabertos.camara.leg.br/api/v2/deputados', {
           params: {
             ...args
           }
         })
-        .then(function(response) {
-          return response.data.dados
-        })
+        .then(response => response.data.dados)
         .catch(function(error) {
           console.log(error)
         })
+
+      for (let i = 0; i < legislators.length; i += 1) {
+        const legislatorComplementaryData = await axios.get(
+          `https://dadosabertos.camara.leg.br/api/v2/deputados/${
+            legislators[i].id
+          }`
+        )
+        legislators[i] = {
+          ...legislators[i],
+          ...legislatorComplementaryData.data.dados
+        }
+      }
+
+      return legislators
     }
   },
   Legislator: {
-    partido(args) {
-      const sigla = args.siglaPartido
+    partido({ siglaPartido: sigla }) {
       return axios
         .get('https://dadosabertos.camara.leg.br/api/v2/partidos', {
           params: {

--- a/src/graphql/resolvers/legislatorResolver.js
+++ b/src/graphql/resolvers/legislatorResolver.js
@@ -3,13 +3,10 @@ const axios = require('axios')
 module.exports = {
   Query: {
     legislators: async (obj, args, context, info) => {
-      const { nome, ordenarPor, siglaPartido } = args
       return axios
         .get('https://dadosabertos.camara.leg.br/api/v2/deputados', {
           params: {
-            nome,
-            ordenarPor,
-            siglaPartido
+            ...args
           }
         })
         .then(function(response) {

--- a/src/graphql/types/chamberType.graphql
+++ b/src/graphql/types/chamberType.graphql
@@ -1,0 +1,8 @@
+type Chamber {
+  andar: String!
+  email: String!
+  nome: String!
+  predio: String!
+  sala: String!
+  telefone: String!
+}

--- a/src/graphql/types/lastStatusType.graphql
+++ b/src/graphql/types/lastStatusType.graphql
@@ -1,0 +1,16 @@
+type LastStatus {
+  condicaoEleitoral: String!
+  data: String!
+  descricao: String!
+  gabinete: [Chamber]
+  id: Int!
+  idLegislatura: Int!
+  nome: String!
+  nomeEleitoral: String!
+  siglaPartido: String!
+  siglaUf: String!
+  situacao: String!
+  uri: String!
+  uriPartido: String!
+  urlFoto: String!
+}

--- a/src/graphql/types/legislatorType.graphql
+++ b/src/graphql/types/legislatorType.graphql
@@ -1,7 +1,7 @@
 type Legislator {
   id: Int!
-  nome: String!
   uri: String!
+  nome: String!
   siglaPartido: String!
   uriPartido: String!
   siglaUf: String!
@@ -12,8 +12,15 @@ type Legislator {
 
 type Query {
   legislators(
+    id: String
     nome: String
-    ordenarPor: String
+    idLegislatura: Int
+    siglaUf: String
     siglaPartido: String
+    siglaSexo: String
+    pagina: Int
+    itens: Int
+    ordenarPor: String
+
   ): [Legislator]
 }

--- a/src/graphql/types/legislatorType.graphql
+++ b/src/graphql/types/legislatorType.graphql
@@ -1,13 +1,24 @@
 type Legislator {
+  cpf: String!
+  dataFalecimento: String
+  dataNascimento: String!
+  escolaridade: String!
   id: Int!
-  uri: String!
-  nome: String!
-  siglaPartido: String!
-  uriPartido: String!
-  siglaUf: String!
   idLegislatura: Int!
-  urlFoto: String!
+  municipioNascimento: String!
+  nome: String!
+  nomeCivil: String!
   partido: [Party]
+  redeSocial: String!
+  sexo: String!
+  siglaPartido: String!
+  siglaUf: String!
+  ufNascimento: String!
+  ultimoStatus: LastStatus!
+  uri: String!
+  uriPartido: String!
+  urlFoto: String!
+  urlWebsite: String!
 }
 
 type Query {


### PR DESCRIPTION
Agora o resolver chama os demais dados dos deputados no endpoint específico de cada um e retorna o objeto completo.
Foi criada a estrutura completa dos dados do parlamentar.
Fixes: https://github.com/SigaLei/api-camara-graphql/issues/6